### PR TITLE
fix TestWrapGroup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sevennt/echo-pprof
+module github.com/sevenNt/echo-pprof
 
 go 1.13
 

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
-github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
 github.com/labstack/echo/v4 v4.1.11 h1:z0BZoArY4FqdpUEl+wlHp4hnr/oSR6MTmQmv8OHSoww=
 github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvfxNnFqi74g=
 github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=

--- a/pprof_test.go
+++ b/pprof_test.go
@@ -12,20 +12,7 @@ func newServer() *echo.Echo {
 	return e
 }
 
-func checkRouters(routers []*echo.Route, t *testing.T) {
-	expectedRouters := map[string]string{
-		"/debug/pprof/":             "IndexHandler",
-		"/debug/pprof/heap":         "HeapHandler",
-		"/debug/pprof/goroutine":    "GoroutineHandler",
-		"/debug/pprof/block":        "BlockHandler",
-		"/debug/pprof/threadcreate": "ThreadCreateHandler",
-		"/debug/pprof/cmdline":      "CmdlineHandler",
-		"/debug/pprof/profile":      "ProfileHandler",
-		"/debug/pprof/symbol":       "SymbolHandler",
-		"/debug/pprof/trace":        "TraceHandler",
-		"/debug/pprof/mutex":        "MutexHandler",
-	}
-
+func checkRouters(routers []*echo.Route, t *testing.T, expectedRouters map[string]string) {
 	for _, router := range routers {
 		if (router.Method != "GET" && router.Method != "POST") || strings.HasSuffix(router.Path, "/*") {
 			continue
@@ -44,7 +31,21 @@ func checkRouters(routers []*echo.Route, t *testing.T) {
 func TestWrap(t *testing.T) {
 	e := newServer()
 	Wrap(e)
-	checkRouters(e.Routes(), t)
+
+	expectedRouters := map[string]string{
+		"/debug/pprof/":             "IndexHandler",
+		"/debug/pprof/heap":         "HeapHandler",
+		"/debug/pprof/goroutine":    "GoroutineHandler",
+		"/debug/pprof/block":        "BlockHandler",
+		"/debug/pprof/threadcreate": "ThreadCreateHandler",
+		"/debug/pprof/cmdline":      "CmdlineHandler",
+		"/debug/pprof/profile":      "ProfileHandler",
+		"/debug/pprof/symbol":       "SymbolHandler",
+		"/debug/pprof/trace":        "TraceHandler",
+		"/debug/pprof/mutex":        "MutexHandler",
+	}
+
+	checkRouters(e.Routes(), t, expectedRouters)
 }
 
 // go test github.com/sevenNt/echo-pprof -v -run=TestWrapGroup\$
@@ -53,6 +54,22 @@ func TestWrapGroup(t *testing.T) {
 		e := newServer()
 		g := e.Group(prefix)
 		WrapGroup(prefix, g)
-		checkRouters(e.Routes(), t)
+		baseRouters := map[string]string{
+			"/":             "IndexHandler",
+			"/heap":         "HeapHandler",
+			"/goroutine":    "GoroutineHandler",
+			"/block":        "BlockHandler",
+			"/threadcreate": "ThreadCreateHandler",
+			"/cmdline":      "CmdlineHandler",
+			"/profile":      "ProfileHandler",
+			"/symbol":       "SymbolHandler",
+			"/trace":        "TraceHandler",
+			"/mutex":        "MutexHandler",
+		}
+		expectedRouters := make(map[string]string, len(baseRouters))
+		for r, h := range baseRouters {
+			expectedRouters[prefix+r] = h
+		}
+		checkRouters(e.Routes(), t, expectedRouters)
 	}
 }


### PR DESCRIPTION
# Issue
TestWrapGroup test expects /debug/pprof, but prefix fails test because of /debug.

# Changes
Test routers for prefixes.