### PR TITLE
Add `IndexHandler` with empty path

### DIFF
--- a/pprof.go
+++ b/pprof.go
@@ -1,9 +1,10 @@
 package echopprof
 
 import (
-	"github.com/labstack/echo/v4"
 	"net/http/pprof"
 	"strings"
+
+	"github.com/labstack/echo/v4"
 )
 
 // Wrap adds several routes from package `net/http/pprof` to *echo.Echo object.
@@ -21,6 +22,7 @@ func WrapGroup(prefix string, g *echo.Group) {
 		Path    string
 		Handler echo.HandlerFunc
 	}{
+		{"GET", "", IndexHandler()},
 		{"GET", "/", IndexHandler()},
 		{"GET", "/heap", HeapHandler()},
 		{"GET", "/goroutine", GoroutineHandler()},

--- a/pprof_test.go
+++ b/pprof_test.go
@@ -33,6 +33,7 @@ func TestWrap(t *testing.T) {
 	Wrap(e)
 
 	expectedRouters := map[string]string{
+		"/debug/pprof":              "IndexHandler",
 		"/debug/pprof/":             "IndexHandler",
 		"/debug/pprof/heap":         "HeapHandler",
 		"/debug/pprof/goroutine":    "GoroutineHandler",
@@ -55,6 +56,7 @@ func TestWrapGroup(t *testing.T) {
 		g := e.Group(prefix)
 		WrapGroup(prefix, g)
 		baseRouters := map[string]string{
+			"":              "IndexHandler",
 			"/":             "IndexHandler",
 			"/heap":         "HeapHandler",
 			"/goroutine":    "GoroutineHandler",


### PR DESCRIPTION
This eliminates the need of putting a slash at the end of the URL. (e.g. `/debug/pprof/` -> notice the slash at the end.) With this commit, sending a request to `/debug/pprof` works.